### PR TITLE
Add GraniteLedger modular order processing app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # GraniteLedger
+
+Modular order-processing demo built on ForgeCore.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python run.py
+```
+
+This starts the ForgeCore runtime and serves the admin API and GraniteLedger routes.
+
+## Testing
+
+```bash
+pytest -q
+```

--- a/modules/events_log/entry.py
+++ b/modules/events_log/entry.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from typing import Any
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+EVENT_TOPICS = [
+    "order.received",
+    "order.updated",
+    "order.status.changed",
+    "order.shipping.selected",
+    "order.shipping.approved",
+    "order.invoice.printed",
+    "order.label.purchased",
+    "order.label.printed",
+    "order.label.voided",
+    "order.completed",
+]
+
+
+class EventsLogModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.module_name = ctx.manifest["name"]
+        self.events = ctx.storage.load(self.module_name, "events", [])
+        for topic in EVENT_TOPICS:
+            ctx.event_bus.subscribe(topic, lambda payload, t=topic: self._handle(t, payload))
+        ctx.registry.bind("events.log@1.0", self)
+
+    def _handle(self, topic: str, payload: Any):
+        rec = {
+            "ts": datetime.utcnow().isoformat(),
+            "topic": topic,
+            "order_id": payload.get("order_id"),
+            "detail": payload.get("detail"),
+            "test": payload.get("test", False),
+        }
+        self.events.append(rec)
+        self.ctx.storage.store(self.module_name, "events", self.events)
+
+    def list_events(self):
+        return list(self.events)
+
+    def setup_routes(self, app: Any):
+        @app.get("/gl/logs")
+        def get_logs():
+            return self.list_events()

--- a/modules/events_log/module.json
+++ b/modules/events_log/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "events_log",
+  "version": "1.0.0",
+  "provides": ["events.log@1.0"],
+  "requires": [],
+  "entry": "entry:EventsLogModule"
+}

--- a/modules/orders_core/entry.py
+++ b/modules/orders_core/entry.py
@@ -1,0 +1,62 @@
+from typing import Any, Dict
+from forgecore.admin_api import HTTPException
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+import os, sys
+sys.path.append(os.path.dirname(__file__))
+from service import OrderService
+from models import Order
+
+
+class OrdersCoreModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.service = OrderService(ctx)
+
+    def on_enable(self):
+        # replace automatic binding with service/model
+        self.ctx.registry.unbind("orders.service@1.0", self)
+        self.ctx.registry.bind("orders.service@1.0", self.service)
+        self.ctx.registry.unbind("orders.models@1.0", self)
+        self.ctx.registry.bind("orders.models@1.0", Order)
+
+    # routes -------------------------------------------------------------
+    def setup_routes(self, app: Any):
+        @app.get("/gl/orders")
+        def list_orders():
+            return [o.dict() for o in self.service.list_orders()]
+
+        @app.get("/gl/orders/{oid}")
+        def get_order(oid: str):
+            order = self.service.get(oid)
+            if not order:
+                raise HTTPException(404)
+            return order.dict()
+
+        @app.post("/gl/orders")
+        def create_order(item: Dict[str, Any]):
+            order = Order.parse_obj(item)
+            self.service.create_or_update(order)
+            return order.dict()
+
+        @app.patch("/gl/orders/{oid}")
+        def update_order(oid: str, item: Dict[str, Any]):
+            order = self.service.update(oid, item)
+            if not order:
+                raise HTTPException(404)
+            return order.dict()
+
+        @app.post("/gl/orders/{oid}/status/{status}")
+        def change_status(oid: str, status: str):
+            try:
+                order = self.service.change_status(oid, status)
+            except ValueError:
+                raise HTTPException(400)
+            if not order:
+                raise HTTPException(404)
+            return order.dict()
+
+        self.app = app

--- a/modules/orders_core/models.py
+++ b/modules/orders_core/models.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from typing import List, Optional, Dict
+from pydantic import BaseModel, Field
+
+
+class Buyer(BaseModel):
+    name: str
+    email: Optional[str] = None
+
+
+class Destination(BaseModel):
+    zip: str
+    city: str
+    state: str
+    country: str
+
+
+class Item(BaseModel):
+    sku: str
+    name: str
+    qty: int = 1
+    weight: float
+
+
+class MoneyTotals(BaseModel):
+    subtotal: float
+    shipping: float
+    tax: float
+    grand_total: float
+
+
+class ShipMethod(BaseModel):
+    carrier: str
+    service: str
+    cost: float
+    eta_days: int
+    rationale: Optional[str] = None
+
+
+class HistoryEntry(BaseModel):
+    ts: datetime
+    event: str
+    detail: str
+
+
+class Order(BaseModel):
+    id: str
+    external_id: Optional[str] = None
+    created_at: datetime
+    buyer: Buyer
+    destination: Destination
+    items: List[Item]
+    shipping_tier: str
+    computed_weight: float = 0.0
+    status: str = "New"
+    proposed_shipping_method: Optional[ShipMethod] = None
+    approved_shipping_method: Optional[ShipMethod] = None
+    tracking_number: Optional[str] = None
+    totals: MoneyTotals
+    history: List[HistoryEntry] = Field(default_factory=list)
+
+    class Config:
+        json_encoders = {datetime: lambda v: v.isoformat()}

--- a/modules/orders_core/module.json
+++ b/modules/orders_core/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "orders_core",
+  "version": "1.0.0",
+  "provides": ["orders.service@1.0", "orders.models@1.0"],
+  "requires": [],
+  "entry": "entry:OrdersCoreModule"
+}

--- a/modules/orders_core/service.py
+++ b/modules/orders_core/service.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+from datetime import datetime
+from typing import Dict, List, Optional
+import os, sys
+sys.path.append(os.path.dirname(__file__))
+from models import Order
+
+
+ALLOWED_STATUS = [
+    "New",
+    "Printed",
+    "Addressed",
+    "Bags Pulled",
+    "Ship Method Chosen",
+    "Shipped",
+    "Completed",
+]
+
+STATUS_FLOW = {
+    "New": ["Printed"],
+    "Printed": ["Addressed"],
+    "Addressed": ["Bags Pulled"],
+    "Bags Pulled": ["Ship Method Chosen"],
+    "Ship Method Chosen": ["Shipped"],
+    "Shipped": ["Completed"],
+    "Completed": [],
+}
+
+
+class OrderService:
+    def __init__(self, ctx) -> None:
+        self.ctx = ctx
+        self.storage = ctx.storage
+        self.event_bus = ctx.event_bus
+        self.module_name = ctx.manifest["name"]
+        self.index: List[str] = self.storage.load(self.module_name, "index", [])
+        self.external: Dict[str, str] = self.storage.load(self.module_name, "external_ids", {})
+
+    # persistence helpers
+    def _save_index(self):
+        self.storage.store(self.module_name, "index", self.index)
+        self.storage.store(self.module_name, "external_ids", self.external)
+
+    def _store_order(self, order: Order):
+        self.storage.store(self.module_name, f"order_{order.id}", order.model_dump(mode="json"))
+        if order.id not in self.index:
+            self.index.append(order.id)
+            self._save_index()
+
+    def _load_order(self, oid: str) -> Optional[Order]:
+        data = self.storage.load(self.module_name, f"order_{oid}")
+        if not data:
+            return None
+        return Order.parse_obj(data)
+
+    # public API
+    def list_orders(self) -> List[Order]:
+        return [self._load_order(i) for i in self.index if self._load_order(i)]
+
+    def get(self, oid: str) -> Optional[Order]:
+        return self._load_order(oid)
+
+    def create_or_update(self, order: Order, test: bool = False) -> Order:
+        if order.external_id and order.external_id in self.external:
+            existing = self._load_order(self.external[order.external_id])
+            if existing:
+                # merge basic fields, keep status etc
+                order.id = existing.id
+                order.status = existing.status
+                order.history = existing.history
+        else:
+            self.external[order.external_id] = order.id if order.external_id else order.id
+        order.history.append({
+            "ts": datetime.utcnow(),
+            "event": "order.received",
+            "detail": "test" if test else "received",
+        })
+        self._store_order(order)
+        payload = {"order_id": order.id, "order": order.model_dump(mode="json"), "test": test}
+        self.event_bus.publish("order.received", payload)
+        return order
+
+    def update(self, oid: str, data: Dict) -> Optional[Order]:
+        order = self._load_order(oid)
+        if not order:
+            return None
+        for k, v in data.items():
+            setattr(order, k, v)
+        order.history.append({
+            "ts": datetime.utcnow(),
+            "event": "order.updated",
+            "detail": "updated",
+        })
+        self._store_order(order)
+        self.event_bus.publish("order.updated", {"order_id": oid, "order": order.model_dump(mode="json")})
+        return order
+
+    def change_status(self, oid: str, new_status: str) -> Optional[Order]:
+        order = self._load_order(oid)
+        if not order:
+            return None
+        if new_status not in ALLOWED_STATUS:
+            raise ValueError("unknown status")
+        if new_status not in STATUS_FLOW.get(order.status, []):
+            raise ValueError("illegal transition")
+        order.status = new_status
+        order.history.append({
+            "ts": datetime.utcnow(),
+            "event": "order.status.changed",
+            "detail": new_status,
+        })
+        self._store_order(order)
+        self.event_bus.publish("order.status.changed", {"order_id": oid, "status": new_status})
+        if new_status == "Completed":
+            self.event_bus.publish("order.completed", {"order_id": oid})
+        return order
+

--- a/modules/printing_service/entry.py
+++ b/modules/printing_service/entry.py
@@ -1,0 +1,101 @@
+import os
+from datetime import datetime
+from typing import Any
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+
+class PrintingServiceModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.service = None
+        ctx.registry.bind("printing.service@1.0", self)
+
+    def on_enable(self):
+        self.service = self.ctx.registry.get("orders.service@1.0")
+
+    # helpers ------------------------------------------------------------
+    def _write_file(self, kind: str, oid: str, content: str) -> str:
+        base = self.ctx.storage._module_dir(self.ctx.manifest["name"])  # type: ignore
+        ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        path = os.path.join(base, kind, oid)
+        os.makedirs(path, exist_ok=True)
+        file_path = os.path.join(path, f"{ts}.txt")
+        with open(file_path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        return file_path
+
+    # core operations ---------------------------------------------------
+    def op_print_invoice(self, oid: str, test: bool = False):
+        order = self.service.get(oid)
+        if not order:
+            raise HTTPException(404)
+        path = self._write_file("invoices", oid, f"Invoice for {oid}")
+        self.ctx.event_bus.publish("order.invoice.printed", {"order_id": oid, "detail": path, "test": test})
+        self.service.change_status(oid, "Printed")
+        return {"path": path}
+
+    def op_print_label(self, oid: str, test: bool = False):
+        order = self.service.get(oid)
+        if not order:
+            raise HTTPException(404)
+        if not order.approved_shipping_method:
+            raise HTTPException(400)
+        tracking = f"TRK{int(datetime.utcnow().timestamp())}"
+        path = self._write_file("labels", oid, f"Label {tracking}")
+        self.service.update(oid, {"tracking_number": tracking})
+        self.ctx.event_bus.publish("order.label.purchased", {"order_id": oid, "detail": tracking, "test": test})
+        self.ctx.event_bus.publish("order.label.printed", {"order_id": oid, "detail": path, "test": test})
+        self.service.change_status(oid, "Shipped")
+        return {"path": path, "tracking": tracking}
+
+    def op_reprint_invoice(self, oid: str, test: bool = False):
+        path = self._write_file("invoices", oid, f"Invoice for {oid} reprint")
+        self.ctx.event_bus.publish("order.invoice.printed", {"order_id": oid, "detail": path, "test": test})
+        return {"path": path}
+
+    def op_reprint_label(self, oid: str, test: bool = False):
+        order = self.service.get(oid)
+        if not order or not order.tracking_number:
+            raise HTTPException(404)
+        path = self._write_file("labels", oid, f"Label {order.tracking_number} reprint")
+        self.ctx.event_bus.publish("order.label.printed", {"order_id": oid, "detail": path, "test": test})
+        return {"path": path}
+
+    def op_void_rebuy(self, oid: str, test: bool = False):
+        order = self.service.get(oid)
+        if not order or not order.tracking_number:
+            raise HTTPException(404)
+        self.ctx.event_bus.publish("order.label.voided", {"order_id": oid, "detail": order.tracking_number, "test": test})
+        tracking = f"TRK{int(datetime.utcnow().timestamp())}R"
+        path = self._write_file("labels", oid, f"Label {tracking}")
+        self.service.update(oid, {"tracking_number": tracking})
+        self.ctx.event_bus.publish("order.label.purchased", {"order_id": oid, "detail": tracking, "test": test})
+        self.ctx.event_bus.publish("order.label.printed", {"order_id": oid, "detail": path, "test": test})
+        return {"path": path, "tracking": tracking}
+
+    # API ---------------------------------------------------------------
+    def setup_routes(self, app: Any):
+        @app.post("/gl/orders/{oid}/print/invoice")
+        def r_print_invoice(oid: str):
+            return self.op_print_invoice(oid)
+
+        @app.post("/gl/orders/{oid}/print/label")
+        def r_print_label(oid: str):
+            return self.op_print_label(oid)
+
+        @app.post("/gl/orders/{oid}/reprint/invoice")
+        def r_reprint_invoice(oid: str):
+            return self.op_reprint_invoice(oid)
+
+        @app.post("/gl/orders/{oid}/reprint/label")
+        def r_reprint_label(oid: str):
+            return self.op_reprint_label(oid)
+
+        @app.post("/gl/orders/{oid}/label/void-rebuy")
+        def r_void_rebuy(oid: str):
+            return self.op_void_rebuy(oid)

--- a/modules/printing_service/module.json
+++ b/modules/printing_service/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "printing_service",
+  "version": "1.0.0",
+  "provides": ["printing.service@1.0"],
+  "requires": ["orders.service@^1.0"],
+  "entry": "entry:PrintingServiceModule"
+}

--- a/modules/shipping_rules/entry.py
+++ b/modules/shipping_rules/entry.py
@@ -1,0 +1,119 @@
+from typing import Any, Dict, List
+from datetime import datetime
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+
+class ShippingRulesModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.service = None
+        ctx.event_bus.subscribe("order.received", self.handle)
+        ctx.event_bus.subscribe("order.updated", self.handle)
+        ctx.registry.bind("shipping.rules@1.0", self)
+
+    def on_enable(self):
+        self.service = self.ctx.registry.get("orders.service@1.0")
+
+    # shipping logic -----------------------------------------------------
+    def compute_weight(self, order: Dict) -> float:
+        total = 0.0
+        for it in order.get("items", []):
+            total += it.get("weight", 0) * it.get("qty", 1)
+        return round(total + 0.5, 2)
+
+    def shipping_options(self, order: Dict) -> List[Dict]:
+        # deterministic stub options
+        return [
+            {"carrier": "USPS", "service": "Ground", "cost": 5.0, "eta_days": 5},
+            {"carrier": "UPS", "service": "Ground", "cost": 5.2, "eta_days": 3},
+            {"carrier": "USPS", "service": "Priority", "cost": 8.0, "eta_days": 2},
+            {"carrier": "Home", "service": "Delivery", "cost": 7.0, "eta_days": 4},
+        ]
+
+    def choose_method(self, order: Dict) -> Dict:
+        zip_code = order["destination"]["zip"]
+        tier = order.get("shipping_tier")
+        options = self.shipping_options(order)
+        # ZIP override
+        if zip_code == "03224":
+            return {"carrier": "Home", "service": "Delivery", "cost": 7.0, "eta_days": 4, "rationale": "zip override"}
+        if tier == "Priority":
+            if zip_code == "03224":
+                return {
+                    "carrier": "Home",
+                    "service": "Delivery",
+                    "cost": 7.0,
+                    "eta_days": 4,
+                    "rationale": "priority zip override",
+                }
+            return {
+                "carrier": "USPS",
+                "service": "Priority",
+                "cost": 8.0,
+                "eta_days": 2,
+                "rationale": "priority",
+            }
+        if tier == "Free":
+            opts = sorted(options[:2], key=lambda o: o["cost"])
+            cheapest = opts[0]
+            candidate = opts[1]
+            if candidate["cost"] - cheapest["cost"] < 0.3 and candidate["eta_days"] < cheapest["eta_days"]:
+                chosen = candidate
+                rationale = "faster within $0.30"
+            else:
+                chosen = cheapest
+                rationale = "cheapest"
+            chosen = dict(chosen)
+            chosen["rationale"] = rationale
+            return chosen
+        # default
+        return {"carrier": "Home", "service": "Delivery", "cost": 7.0, "eta_days": 4, "rationale": "default"}
+
+    def handle(self, payload: Dict):
+        order = payload.get("order")
+        if not order:
+            return
+        oid = payload["order_id"]
+        weight = self.compute_weight(order)
+        method = self.choose_method(order)
+        changed = {}
+        if order.get("computed_weight") != weight:
+            changed["computed_weight"] = weight
+        if order.get("proposed_shipping_method") != method:
+            changed["proposed_shipping_method"] = method
+        if changed:
+            self.service.update(oid, changed)
+            self.ctx.event_bus.publish(
+                "order.shipping.selected",
+                {"order_id": oid, "method": method},
+            )
+
+    # routes -------------------------------------------------------------
+    def setup_routes(self, app: Any):
+        @app.get("/gl/orders/{oid}/shipping/options")
+        def options(oid: str):
+            order = self.service.get(oid)
+            if not order:
+                raise HTTPException(404)
+            opts = self.shipping_options(order.dict())[:2]
+            return opts
+
+        @app.post("/gl/orders/{oid}/shipping/approve")
+        def approve(oid: str):
+            order = self.service.get(oid)
+            if not order:
+                raise HTTPException(404)
+            method = order.proposed_shipping_method
+            if not method:
+                raise HTTPException(400)
+            self.service.update(oid, {"approved_shipping_method": method})
+            self.ctx.event_bus.publish(
+                "order.shipping.approved", {"order_id": oid, "method": method}
+            )
+            self.service.change_status(oid, "Ship Method Chosen")
+            return method

--- a/modules/shipping_rules/module.json
+++ b/modules/shipping_rules/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "shipping_rules",
+  "version": "1.0.0",
+  "provides": ["shipping.rules@1.0"],
+  "requires": ["orders.service@^1.0"],
+  "entry": "entry:ShippingRulesModule"
+}

--- a/modules/status_dashboard/entry.py
+++ b/modules/status_dashboard/entry.py
@@ -1,0 +1,21 @@
+import os
+from typing import Any
+
+try:
+    from fastapi import FastAPI
+    from fastapi.responses import HTMLResponse
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI as HTMLResponse  # type: ignore
+
+
+class DashboardModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        ctx.registry.bind("ui.dashboard@1.0", self)
+
+    def setup_routes(self, app: Any):
+        @app.get("/gl/ui")
+        def ui():
+            path = os.path.join(self.ctx.module_path, "static", "index.html")
+            with open(path, "r", encoding="utf-8") as fh:
+                return fh.read()

--- a/modules/status_dashboard/module.json
+++ b/modules/status_dashboard/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "status_dashboard",
+  "version": "1.0.0",
+  "provides": ["ui.dashboard@1.0"],
+  "requires": ["orders.service@^1.0", "shipping.rules@^1.0", "printing.service@^1.0", "events.log@^1.0"],
+  "entry": "entry:DashboardModule"
+}

--- a/modules/status_dashboard/static/index.html
+++ b/modules/status_dashboard/static/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><body>
+<h1>GraniteLedger Dashboard</h1>
+<p>Minimal placeholder UI.</p>
+</body></html>

--- a/modules/test_kits/entry.py
+++ b/modules/test_kits/entry.py
@@ -1,0 +1,54 @@
+import uuid
+from typing import Any
+from datetime import datetime
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+
+class TestKitsModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.orders = ctx.registry.get("orders.service@1.0")
+        self.printing = ctx.registry.get("printing.service@1.0")
+        self.OrderModel = ctx.registry.get("orders.models@1.0")
+        ctx.registry.bind("tests.kit@1.0", self)
+
+    def setup_routes(self, app: Any):
+        @app.post("/gl/test/order")
+        def test_order():
+            oid = str(uuid.uuid4())
+            order = self.OrderModel(
+                id=oid,
+                external_id=oid,
+                created_at=datetime.utcnow(),
+                buyer={"name": "Test Buyer"},
+                destination={"zip": "99999", "city": "X", "state": "YY", "country": "US"},
+                items=[{"sku": "SKU1", "name": "Item", "qty": 1, "weight": 1.0}],
+                shipping_tier="Free",
+                totals={"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+            )
+            self.orders.create_or_update(order, test=True)
+            return {"id": oid}
+
+        @app.post("/gl/test/print")
+        def test_print():
+            orders = self.orders.list_orders()
+            if not orders:
+                raise HTTPException(404)
+            oid = orders[-1].id
+            self.printing.op_print_invoice(oid, test=True)
+            return {"id": oid}
+
+        @app.post("/gl/test/ship")
+        def test_ship():
+            orders = self.orders.list_orders()
+            if not orders:
+                raise HTTPException(404)
+            oid = orders[-1].id
+            self.orders.update(oid, {"approved_shipping_method": {"carrier": "USPS", "service": "Ground", "cost": 5.0, "eta_days": 5}})
+            self.printing.op_print_label(oid, test=True)
+            return {"id": oid}

--- a/modules/test_kits/module.json
+++ b/modules/test_kits/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "test_kits",
+  "version": "1.0.0",
+  "provides": ["tests.kit@1.0"],
+  "requires": ["orders.service@^1.0", "printing.service@^1.0"],
+  "entry": "entry:TestKitsModule"
+}

--- a/modules/volusion_webhook/entry.py
+++ b/modules/volusion_webhook/entry.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+import os, sys
+sys.path.append(os.path.dirname(__file__))
+from normalizer import normalize
+
+
+class VolusionWebhookModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.service = None
+        self.OrderModel = None
+        ctx.event_bus.subscribe("order.completed", self.on_completed)
+        ctx.registry.bind("webhooks.volusion@1.0", self)
+
+    def on_enable(self):
+        self.service = self.ctx.registry.get("orders.service@1.0")
+        self.OrderModel = self.ctx.registry.get("orders.models@1.0")
+
+    def on_completed(self, payload: Dict[str, Any]):
+        # stub callback
+        self.ctx.event_bus.publish(
+            "volusion.sync", {"order_id": payload.get("order_id")}
+        )
+
+    def ingest_payload(self, item: Dict[str, Any]):
+        data = normalize(item)
+        order = self.OrderModel.parse_obj(data)
+        self.service.create_or_update(order, test=item.get("test") == True)
+        return {"status": "ok", "id": order.id}
+
+    def setup_routes(self, app: Any):
+        @app.post("/gl/webhooks/volusion")
+        def ingest(item: Dict[str, Any]):
+            return self.ingest_payload(item)

--- a/modules/volusion_webhook/module.json
+++ b/modules/volusion_webhook/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "volusion_webhook",
+  "version": "1.0.0",
+  "provides": ["webhooks.volusion@1.0"],
+  "requires": ["orders.service@^1.0"],
+  "entry": "entry:VolusionWebhookModule"
+}

--- a/modules/volusion_webhook/normalizer.py
+++ b/modules/volusion_webhook/normalizer.py
@@ -1,0 +1,3 @@
+def normalize(payload):
+    # For this demo, payload already resembles Order; ensure required fields.
+    return payload

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pydantic
+fastapi
+uvicorn
+pytest

--- a/run.py
+++ b/run.py
@@ -1,0 +1,25 @@
+from forgecore.runtime import create_runtime
+from forgecore.admin_api import create_app
+
+
+def build_app():
+    rt = create_runtime("modules")
+    rt.start()
+    app = create_app(rt)
+    for state in rt.loader.modules.values():
+        if hasattr(state.instance, "setup_routes"):
+            state.instance.setup_routes(app)
+    return app, rt
+
+
+if __name__ == "__main__":
+    app, _ = build_app()
+    # when running via 'python run.py', start uvicorn if available
+    try:
+        import uvicorn
+
+        uvicorn.run(app, host="0.0.0.0", port=8765)
+    except Exception:
+        from forgecore.admin_api import Response
+
+        print("App built. Use a WSGI server to run.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+import shutil
+import os
+import pytest
+import sys
+BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(BASE)
+sys.path.append(os.path.join(BASE, "ForgeCore"))
+
+from forgecore.runtime import create_runtime
+
+
+@pytest.fixture
+def runtime():
+    shutil.rmtree("modules/_storage", ignore_errors=True)
+    rt = create_runtime("modules")
+    rt.start()
+    yield rt
+    shutil.rmtree("modules/_storage", ignore_errors=True)
+
+
+@pytest.fixture
+def orders(runtime):
+    return runtime.registry.get("orders.service@1.0")
+
+
+@pytest.fixture
+def printing(runtime):
+    return runtime.registry.get("printing.service@1.0")
+
+
+@pytest.fixture
+def events(runtime):
+    return runtime.registry.get("events.log@1.0")
+
+
+@pytest.fixture
+def order_model(runtime):
+    return runtime.registry.get("orders.models@1.0")
+
+
+@pytest.fixture
+def volusion(runtime):
+    return runtime.registry.get("webhooks.volusion@1.0")

--- a/tests/test_order_flow.py
+++ b/tests/test_order_flow.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+
+def make_order(id):
+    return {
+        "id": id,
+        "external_id": id,
+        "created_at": datetime.utcnow(),
+        "buyer": {"name": "Flow"},
+        "destination": {"zip": "99999", "city": "X", "state": "Y", "country": "US"},
+        "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": 1.0}],
+        "shipping_tier": "Free",
+        "totals": {"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+    }
+
+
+def test_full_flow(orders, order_model, printing, events, runtime):
+    order = order_model(**make_order("x1"))
+    orders.create_or_update(order)
+    # print invoice
+    printing.op_print_invoice("x1")
+    orders.change_status("x1", "Addressed")
+    orders.change_status("x1", "Bags Pulled")
+    # approve shipping
+    method = orders.get("x1").proposed_shipping_method
+    orders.update("x1", {"approved_shipping_method": method})
+    runtime.event_bus.publish("order.shipping.approved", {"order_id": "x1", "method": method})
+    orders.change_status("x1", "Ship Method Chosen")
+    # print label
+    printing.op_print_label("x1")
+    orders.change_status("x1", "Completed")
+    data = orders.get("x1").dict()
+    assert data["status"] == "Completed"
+    assert data["tracking_number"] is not None
+    topics = [e["topic"] for e in events.list_events()]
+    for t in ["order.received", "order.invoice.printed", "order.label.printed", "order.completed"]:
+        assert t in topics

--- a/tests/test_shipping_rules.py
+++ b/tests/test_shipping_rules.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+
+
+def make_order(id, tier, zip_code, weight=1.0):
+    return {
+        "id": id,
+        "external_id": id,
+        "created_at": datetime.utcnow(),
+        "buyer": {"name": "Test"},
+        "destination": {"zip": zip_code, "city": "X", "state": "Y", "country": "US"},
+        "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": weight}],
+        "shipping_tier": tier,
+        "totals": {"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+    }
+
+
+def test_weight_and_free_rule(orders, order_model):
+    order = order_model(**make_order("1", "Free", "99999"))
+    orders.create_or_update(order)
+    data = orders.get("1").dict()
+    assert data["computed_weight"] == 1.5
+    assert data["proposed_shipping_method"]["carrier"] == "UPS"
+
+
+def test_zip_override(orders, order_model):
+    order = order_model(**make_order("2", "Free", "03224"))
+    orders.create_or_update(order)
+    data = orders.get("2").dict()
+    assert data["proposed_shipping_method"]["carrier"] == "Home"
+
+
+def test_priority_zip_override(orders, order_model):
+    order = order_model(**make_order("3", "Priority", "03224"))
+    orders.create_or_update(order)
+    data = orders.get("3").dict()
+    assert data["proposed_shipping_method"]["carrier"] == "Home"

--- a/tests/test_webhook_idempotency.py
+++ b/tests/test_webhook_idempotency.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+payload = {
+    "id": "ext1",
+    "created_at": datetime.utcnow(),
+    "buyer": {"name": "Webhook"},
+    "destination": {"zip": "99999", "city": "X", "state": "Y", "country": "US"},
+    "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": 1.0}],
+    "shipping_tier": "Free",
+    "totals": {"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+}
+
+
+def test_idempotent_webhook(volusion, orders):
+    volusion.ingest_payload(payload)
+    volusion.ingest_payload(payload)
+    assert len(orders.list_orders()) == 1


### PR DESCRIPTION
## Summary
- implement orders core service with status transitions and persistence
- add shipping, printing, webhook, events, dashboard and test kit modules
- provide integration tests for shipping rules, webhook idempotency and full order flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa212041a4832e8cdaa4cadb68a0c3