### PR TITLE
Add GraniteLedger modular order processing app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # GraniteLedger
+
+Modular order-processing demo built on ForgeCore.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python run.py
+```
+
+Open the dashboard at [http://127.0.0.1:8765/gl/ui](http://127.0.0.1:8765/gl/ui).
+
+Helpful test endpoints:
+
+```bash
+curl -XPOST http://127.0.0.1:8765/gl/test/order
+curl -XPOST http://127.0.0.1:8765/gl/test/print
+curl -XPOST http://127.0.0.1:8765/gl/test/ship
+```
+
+Batch routes:
+
+```bash
+curl -XPOST http://127.0.0.1:8765/gl/orders/batch/print/invoices -d '{"ids":["1"]}'
+curl -XPOST http://127.0.0.1:8765/gl/orders/batch/status -d '{"ids":["1"],"status":"Completed"}'
+```
+
+Printed invoices and labels are saved under `modules/printing_service/_storage/`.
+
+Note: avoid creating any folder named `fastapi` to prevent import shadowing.
+
+## Testing
+
+```bash
+pytest -q
+```

--- a/modules/events_log/entry.py
+++ b/modules/events_log/entry.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from typing import Any
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+EVENT_TOPICS = [
+    "order.received",
+    "order.updated",
+    "order.status.changed",
+    "order.shipping.selected",
+    "order.shipping.approved",
+    "order.invoice.printed",
+    "order.label.purchased",
+    "order.label.printed",
+    "order.label.voided",
+    "order.completed",
+    "addressbook.added",
+]
+
+
+class EventsLogModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.module_name = ctx.manifest["name"]
+        self.events = ctx.storage.load(self.module_name, "events", [])
+        for topic in EVENT_TOPICS:
+            ctx.event_bus.subscribe(topic, lambda payload, t=topic: self._handle(t, payload))
+        ctx.registry.bind("events.log@1.0", self)
+
+    def _handle(self, topic: str, payload: Any):
+        rec = {
+            "ts": datetime.utcnow().isoformat(),
+            "topic": topic,
+            "order_id": payload.get("order_id"),
+            "detail": payload.get("detail"),
+            "test": payload.get("test", False),
+        }
+        self.events.append(rec)
+        self.ctx.storage.store(self.module_name, "events", self.events)
+
+    def list_events(self, topic: str | None = None, q: str | None = None, since: str | None = None):
+        evs = list(self.events)
+        if topic:
+            evs = [e for e in evs if e["topic"].startswith(topic)]
+        if q:
+            evs = [e for e in evs if q.lower() in (e.get("detail") or "").lower()]
+        if since:
+            try:
+                dt = datetime.fromisoformat(since)
+                evs = [e for e in evs if datetime.fromisoformat(e["ts"]) >= dt]
+            except Exception:  # pragma: no cover
+                pass
+        evs.sort(key=lambda e: e["ts"], reverse=True)
+        return evs
+
+    def setup_routes(self, app: Any):
+        @app.get("/gl/logs")
+        def get_logs(topic: str = "", q: str = "", since: str = ""):
+            return self.list_events(topic or None, q or None, since or None)

--- a/modules/events_log/module.json
+++ b/modules/events_log/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "events_log",
+  "version": "1.0.0",
+  "provides": ["events.log@1.0"],
+  "requires": [],
+  "entry": "entry:EventsLogModule"
+}

--- a/modules/orders_core/entry.py
+++ b/modules/orders_core/entry.py
@@ -1,0 +1,120 @@
+from typing import Any, Dict
+from forgecore.admin_api import HTTPException
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+import os, sys
+sys.path.append(os.path.dirname(__file__))
+from service import OrderService
+from models import Order
+
+
+class OrdersCoreModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.service = OrderService(ctx)
+
+    def on_enable(self):
+        # replace automatic binding with service/model
+        self.ctx.registry.unbind("orders.service@1.0", self)
+        self.ctx.registry.bind("orders.service@1.0", self.service)
+        self.ctx.registry.unbind("orders.models@1.0", self)
+        self.ctx.registry.bind("orders.models@1.0", Order)
+        # optional access to printing service for batch ops
+        try:
+            self.printing = self.ctx.registry.get("printing.service@1.0")
+        except Exception:  # pragma: no cover
+            self.printing = None
+
+    # routes -------------------------------------------------------------
+    def setup_routes(self, app: Any):
+        @app.get("/gl/orders")
+        def list_orders():
+            return [o.dict() for o in self.service.list_orders()]
+
+        @app.get("/gl/orders/{oid}")
+        def get_order(oid: str):
+            order = self.service.get(oid)
+            if not order:
+                raise HTTPException(404)
+            return order.dict()
+
+        @app.post("/gl/orders")
+        def create_order(item: Dict[str, Any]):
+            order = Order.parse_obj(item)
+            self.service.create_or_update(order)
+            return order.dict()
+
+        @app.patch("/gl/orders/{oid}")
+        def update_order(oid: str, item: Dict[str, Any]):
+            order = self.service.update(oid, item)
+            if not order:
+                raise HTTPException(404)
+            return order.dict()
+
+        @app.post("/gl/orders/{oid}/status/{status}")
+        def change_status(oid: str, status: str):
+            try:
+                order = self.service.change_status(oid, status)
+            except ValueError:
+                raise HTTPException(400)
+            if not order:
+                raise HTTPException(404)
+            return order.dict()
+
+        @app.post("/gl/orders/{oid}/addressed")
+        def addressed(oid: str):
+            try:
+                order = self.service.change_status(oid, "Addressed")
+            except ValueError:
+                raise HTTPException(400)
+            if not order:
+                raise HTTPException(404)
+            self.service.append_history(
+                oid, "addressbook.added", "Address pushed to Apple Contacts (stub)"
+            )
+            self.ctx.event_bus.publish("addressbook.added", {"order_id": oid})
+            return self.service.get(oid).dict()
+
+        @app.post("/gl/orders/batch/print/invoices")
+        def batch_print_invoices(ids: Dict[str, Any]):
+            if not self.printing:
+                raise HTTPException(500, "printing service unavailable")
+            results = {}
+            for oid in ids.get("ids", []):
+                try:
+                    results[oid] = self.printing.op_print_invoice(oid)
+                except Exception as e:  # pragma: no cover
+                    results[oid] = {"error": str(e)}
+            return results
+
+            
+        @app.post("/gl/orders/batch/print/labels")
+        def batch_print_labels(ids: Dict[str, Any]):
+            if not self.printing:
+                raise HTTPException(500, "printing service unavailable")
+            results = {}
+            for oid in ids.get("ids", []):
+                try:
+                    results[oid] = self.printing.op_print_label(oid)
+                except Exception as e:  # pragma: no cover
+                    results[oid] = {"error": str(e)}
+            return results
+
+        @app.post("/gl/orders/batch/status")
+        def batch_status(payload: Dict[str, Any]):
+            status = payload.get("status")
+            results = {}
+            for oid in payload.get("ids", []):
+                try:
+                    order = self.service.change_status(oid, status)
+                    if not order:
+                        raise ValueError("not found")
+                    results[oid] = {"ok": True}
+                except Exception as e:
+                    results[oid] = {"error": str(e)}
+            return results
+
+        self.app = app

--- a/modules/orders_core/models.py
+++ b/modules/orders_core/models.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from typing import List, Optional, Dict
+from pydantic import BaseModel, Field
+
+
+class Buyer(BaseModel):
+    name: str
+    email: Optional[str] = None
+
+
+class Destination(BaseModel):
+    zip: str
+    city: str
+    state: str
+    country: str
+
+
+class Item(BaseModel):
+    sku: str
+    name: str
+    qty: int = 1
+    weight: float
+
+
+class MoneyTotals(BaseModel):
+    subtotal: float
+    shipping: float
+    tax: float
+    grand_total: float
+
+
+class ShipMethod(BaseModel):
+    carrier: str
+    service: str
+    cost: float
+    eta_days: int
+    rationale: Optional[str] = None
+
+
+class HistoryEntry(BaseModel):
+    ts: datetime
+    event: str
+    detail: str
+
+
+class Order(BaseModel):
+    id: str
+    external_id: Optional[str] = None
+    created_at: datetime
+    buyer: Buyer
+    destination: Destination
+    items: List[Item]
+    shipping_tier: str
+    computed_weight: float = 0.0
+    status: str = "New"
+    proposed_shipping_method: Optional[ShipMethod] = None
+    approved_shipping_method: Optional[ShipMethod] = None
+    tracking_number: Optional[str] = None
+    totals: MoneyTotals
+    history: List[HistoryEntry] = Field(default_factory=list)
+
+    class Config:
+        json_encoders = {datetime: lambda v: v.isoformat()}

--- a/modules/orders_core/module.json
+++ b/modules/orders_core/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "orders_core",
+  "version": "1.0.0",
+  "provides": ["orders.service@1.0", "orders.models@1.0"],
+  "requires": [],
+  "entry": "entry:OrdersCoreModule"
+}

--- a/modules/orders_core/service.py
+++ b/modules/orders_core/service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+from datetime import datetime
+from typing import Dict, List, Optional
+import os, sys
+sys.path.append(os.path.dirname(__file__))
+from models import Order
+
+
+ALLOWED_STATUS = [
+    "New",
+    "Printed",
+    "Addressed",
+    "Bags Pulled",
+    "Ship Method Chosen",
+    "Shipped",
+    "Completed",
+]
+
+STATUS_FLOW = {
+    "New": ["Printed"],
+    "Printed": ["Addressed"],
+    "Addressed": ["Bags Pulled"],
+    "Bags Pulled": ["Ship Method Chosen"],
+    "Ship Method Chosen": ["Shipped"],
+    "Shipped": ["Completed"],
+    "Completed": [],
+}
+
+
+class OrderService:
+    def __init__(self, ctx) -> None:
+        self.ctx = ctx
+        self.storage = ctx.storage
+        self.event_bus = ctx.event_bus
+        self.module_name = ctx.manifest["name"]
+        self.index: List[str] = self.storage.load(self.module_name, "index", [])
+        self.external: Dict[str, str] = self.storage.load(self.module_name, "external_ids", {})
+
+    # persistence helpers
+    def _save_index(self):
+        self.storage.store(self.module_name, "index", self.index)
+        self.storage.store(self.module_name, "external_ids", self.external)
+
+    def _store_order(self, order: Order):
+        self.storage.store(self.module_name, f"order_{order.id}", order.model_dump(mode="json"))
+        if order.id not in self.index:
+            self.index.append(order.id)
+            self._save_index()
+
+    def _load_order(self, oid: str) -> Optional[Order]:
+        data = self.storage.load(self.module_name, f"order_{oid}")
+        if not data:
+            return None
+        return Order.parse_obj(data)
+
+    # public API
+    def list_orders(self) -> List[Order]:
+        return [self._load_order(i) for i in self.index if self._load_order(i)]
+
+    def get(self, oid: str) -> Optional[Order]:
+        return self._load_order(oid)
+
+    def create_or_update(self, order: Order, test: bool = False) -> Order:
+        if order.external_id and order.external_id in self.external:
+            existing = self._load_order(self.external[order.external_id])
+            if existing:
+                # merge basic fields, keep status etc
+                order.id = existing.id
+                order.status = existing.status
+                order.history = existing.history
+        else:
+            self.external[order.external_id] = order.id if order.external_id else order.id
+        order.history.append({
+            "ts": datetime.utcnow(),
+            "event": "order.received",
+            "detail": "test" if test else "received",
+        })
+        self._store_order(order)
+        payload = {"order_id": order.id, "order": order.model_dump(mode="json"), "test": test}
+        self.event_bus.publish("order.received", payload)
+        return order
+
+    def update(self, oid: str, data: Dict) -> Optional[Order]:
+        order = self._load_order(oid)
+        if not order:
+            return None
+        for k, v in data.items():
+            setattr(order, k, v)
+        order.history.append({
+            "ts": datetime.utcnow(),
+            "event": "order.updated",
+            "detail": "updated",
+        })
+        self._store_order(order)
+        self.event_bus.publish("order.updated", {"order_id": oid, "order": order.model_dump(mode="json")})
+        return order
+
+    def change_status(self, oid: str, new_status: str) -> Optional[Order]:
+        order = self._load_order(oid)
+        if not order:
+            return None
+        if new_status not in ALLOWED_STATUS:
+            raise ValueError("unknown status")
+        if new_status not in STATUS_FLOW.get(order.status, []):
+            raise ValueError("illegal transition")
+        order.status = new_status
+        order.history.append({
+            "ts": datetime.utcnow(),
+            "event": "order.status.changed",
+            "detail": new_status,
+        })
+        self._store_order(order)
+        self.event_bus.publish("order.status.changed", {"order_id": oid, "status": new_status})
+        if new_status == "Completed":
+            self.event_bus.publish("order.completed", {"order_id": oid})
+        return order
+
+    def append_history(self, oid: str, event: str, detail: str) -> Optional[Order]:
+        order = self._load_order(oid)
+        if not order:
+            return None
+        order.history.append({
+            "ts": datetime.utcnow(),
+            "event": event,
+            "detail": detail,
+        })
+        self._store_order(order)
+        return order
+

--- a/modules/printing_service/entry.py
+++ b/modules/printing_service/entry.py
@@ -1,0 +1,122 @@
+import os
+from datetime import datetime
+from typing import Any, Dict
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+
+class PrintingServiceModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.service = None
+        ctx.registry.bind("printing.service@1.0", self)
+
+    def on_enable(self):
+        self.service = self.ctx.registry.get("orders.service@1.0")
+
+    # helpers ------------------------------------------------------------
+    def _write_file(self, kind: str, oid: str, content: str) -> Dict[str, str]:
+        base = self.ctx.storage._module_dir(self.ctx.manifest["name"])  # type: ignore
+        ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        path = os.path.join(base, kind, oid)
+        os.makedirs(path, exist_ok=True)
+        html_path = os.path.join(path, f"{ts}.html")
+        with open(html_path, "w", encoding="utf-8") as fh:
+            fh.write(f"<html><body><pre>{content}</pre></body></html>")
+        txt_path = os.path.join(path, f"{ts}.txt")
+        with open(txt_path, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        return {"html": html_path, "txt": txt_path}
+
+    # core operations ---------------------------------------------------
+    def op_print_invoice(self, oid: str, test: bool = False):
+        order = self.service.get(oid)
+        if not order:
+            raise HTTPException(404)
+        paths = self._write_file("invoices", oid, f"Invoice for {oid}")
+        self.ctx.event_bus.publish(
+            "order.invoice.printed", {"order_id": oid, "detail": paths["html"], "test": test}
+        )
+        self.service.change_status(oid, "Printed")
+        return paths
+
+    def op_print_label(self, oid: str, test: bool = False):
+        order = self.service.get(oid)
+        if not order:
+            raise HTTPException(404)
+        if not order.approved_shipping_method:
+            raise HTTPException(400)
+        tracking = f"TRK{int(datetime.utcnow().timestamp())}"
+        paths = self._write_file("labels", oid, f"Label {tracking}")
+        self.service.update(oid, {"tracking_number": tracking})
+        self.ctx.event_bus.publish(
+            "order.label.purchased", {"order_id": oid, "detail": tracking, "test": test}
+        )
+        self.ctx.event_bus.publish(
+            "order.label.printed", {"order_id": oid, "detail": paths["html"], "test": test}
+        )
+        self.service.change_status(oid, "Shipped")
+        result = dict(paths)
+        result["tracking"] = tracking
+        return result
+
+    def op_reprint_invoice(self, oid: str, test: bool = False):
+        paths = self._write_file("invoices", oid, f"Invoice for {oid} reprint")
+        self.ctx.event_bus.publish(
+            "order.invoice.printed", {"order_id": oid, "detail": paths["html"], "test": test}
+        )
+        return paths
+
+    def op_reprint_label(self, oid: str, test: bool = False):
+        order = self.service.get(oid)
+        if not order or not order.tracking_number:
+            raise HTTPException(404)
+        paths = self._write_file("labels", oid, f"Label {order.tracking_number} reprint")
+        self.ctx.event_bus.publish(
+            "order.label.printed", {"order_id": oid, "detail": paths["html"], "test": test}
+        )
+        return paths
+
+    def op_void_rebuy(self, oid: str, test: bool = False):
+        order = self.service.get(oid)
+        if not order or not order.tracking_number:
+            raise HTTPException(404)
+        self.ctx.event_bus.publish("order.label.voided", {"order_id": oid, "detail": order.tracking_number, "test": test})
+        tracking = f"TRK{int(datetime.utcnow().timestamp())}R"
+        paths = self._write_file("labels", oid, f"Label {tracking}")
+        self.service.update(oid, {"tracking_number": tracking})
+        self.ctx.event_bus.publish(
+            "order.label.purchased", {"order_id": oid, "detail": tracking, "test": test}
+        )
+        self.ctx.event_bus.publish(
+            "order.label.printed", {"order_id": oid, "detail": paths["html"], "test": test}
+        )
+        result = dict(paths)
+        result["tracking"] = tracking
+        return result
+
+    # API ---------------------------------------------------------------
+    def setup_routes(self, app: Any):
+        @app.post("/gl/orders/{oid}/print/invoice")
+        def r_print_invoice(oid: str):
+            return self.op_print_invoice(oid)
+
+        @app.post("/gl/orders/{oid}/print/label")
+        def r_print_label(oid: str):
+            return self.op_print_label(oid)
+
+        @app.post("/gl/orders/{oid}/reprint/invoice")
+        def r_reprint_invoice(oid: str):
+            return self.op_reprint_invoice(oid)
+
+        @app.post("/gl/orders/{oid}/reprint/label")
+        def r_reprint_label(oid: str):
+            return self.op_reprint_label(oid)
+
+        @app.post("/gl/orders/{oid}/label/void-rebuy")
+        def r_void_rebuy(oid: str):
+            return self.op_void_rebuy(oid)

--- a/modules/printing_service/module.json
+++ b/modules/printing_service/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "printing_service",
+  "version": "1.0.0",
+  "provides": ["printing.service@1.0"],
+  "requires": ["orders.service@^1.0"],
+  "entry": "entry:PrintingServiceModule"
+}

--- a/modules/shipping_rules/entry.py
+++ b/modules/shipping_rules/entry.py
@@ -1,0 +1,127 @@
+from typing import Any, Dict, List
+from datetime import datetime
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+
+class ShippingRulesModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.service = None
+        ctx.event_bus.subscribe("order.received", self.handle)
+        ctx.event_bus.subscribe("order.updated", self.handle)
+        ctx.registry.bind("shipping.rules@1.0", self)
+
+    def on_enable(self):
+        self.service = self.ctx.registry.get("orders.service@1.0")
+
+    # shipping logic -----------------------------------------------------
+    def compute_weight(self, order: Dict) -> float:
+        total = 0.0
+        for it in order.get("items", []):
+            total += it.get("weight", 0) * it.get("qty", 1)
+        return round(total + 0.5, 2)
+
+    def shipping_options(self, order: Dict) -> List[Dict]:
+        weight = self.compute_weight(order)
+        base = 5.0 + weight * 0.1
+        last = int(order["destination"]["zip"][-1])
+        diff = (last % 5) / 10.0
+        cheapest = {"carrier": "USPS", "service": "Ground", "cost": round(base, 2), "eta_days": 5}
+        candidate = {
+            "carrier": "UPS",
+            "service": "Ground",
+            "cost": round(base + diff + 0.1, 2),
+            "eta_days": 3,
+        }
+        priority = {
+            "carrier": "USPS",
+            "service": "Priority",
+            "cost": round(base + 3, 2),
+            "eta_days": 2,
+        }
+        home = {
+            "carrier": "Home",
+            "service": "Delivery",
+            "cost": round(base + 2, 2),
+            "eta_days": 4,
+        }
+        return [cheapest, candidate, priority, home]
+
+    def choose_method(self, order: Dict) -> Dict:
+        zip_code = order["destination"]["zip"]
+        tier = order.get("shipping_tier")
+        options = self.shipping_options(order)
+        # ZIP override always home delivery
+        if zip_code == "03224":
+            chosen = options[3]
+            chosen = dict(chosen)
+            chosen["rationale"] = "zip override"
+            return chosen
+        if tier == "Priority":
+            chosen = options[2]
+            chosen = dict(chosen)
+            chosen["rationale"] = "priority"
+            return chosen
+        if tier == "Free":
+            opts = sorted(options[:2], key=lambda o: o["cost"])
+            cheapest, candidate = opts
+            if (candidate["cost"] - cheapest["cost"] < 0.3) and (candidate["eta_days"] < cheapest["eta_days"]):
+                chosen = dict(candidate)
+                chosen["rationale"] = "faster within $0.30"
+            else:
+                chosen = dict(cheapest)
+                chosen["rationale"] = "cheapest"
+            return chosen
+        # default fallback
+        chosen = dict(options[3])
+        chosen["rationale"] = "default"
+        return chosen
+
+    def handle(self, payload: Dict):
+        order = payload.get("order")
+        if not order:
+            return
+        oid = payload["order_id"]
+        weight = self.compute_weight(order)
+        method = self.choose_method(order)
+        changed = {}
+        if order.get("computed_weight") != weight:
+            changed["computed_weight"] = weight
+        if order.get("proposed_shipping_method") != method:
+            changed["proposed_shipping_method"] = method
+        if changed:
+            self.service.update(oid, changed)
+            self.ctx.event_bus.publish(
+                "order.shipping.selected",
+                {"order_id": oid, "method": method},
+            )
+
+    # routes -------------------------------------------------------------
+    def setup_routes(self, app: Any):
+        @app.get("/gl/orders/{oid}/shipping/options")
+        def options(oid: str):
+            order = self.service.get(oid)
+            if not order:
+                raise HTTPException(404)
+            opts = self.shipping_options(order.dict())[:2]
+            return opts
+
+        @app.post("/gl/orders/{oid}/shipping/approve")
+        def approve(oid: str):
+            order = self.service.get(oid)
+            if not order:
+                raise HTTPException(404)
+            method = order.proposed_shipping_method
+            if not method:
+                raise HTTPException(400)
+            self.service.update(oid, {"approved_shipping_method": method})
+            self.ctx.event_bus.publish(
+                "order.shipping.approved", {"order_id": oid, "method": method}
+            )
+            self.service.change_status(oid, "Ship Method Chosen")
+            return method

--- a/modules/shipping_rules/module.json
+++ b/modules/shipping_rules/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "shipping_rules",
+  "version": "1.0.0",
+  "provides": ["shipping.rules@1.0"],
+  "requires": ["orders.service@^1.0"],
+  "entry": "entry:ShippingRulesModule"
+}

--- a/modules/status_dashboard/entry.py
+++ b/modules/status_dashboard/entry.py
@@ -1,0 +1,42 @@
+import os
+from typing import Any
+
+try:
+    from fastapi import FastAPI
+    from fastapi.responses import HTMLResponse, Response
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI, Response  # type: ignore
+    HTMLResponse = Response  # type: ignore
+
+
+class DashboardModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        ctx.registry.bind("ui.dashboard@1.0", self)
+
+    def setup_routes(self, app: Any):
+        static_dir = os.path.join(self.ctx.module_path, "static")
+
+        @app.get("/gl/ui", response_class=HTMLResponse)
+        def ui():
+            path = os.path.join(static_dir, "index.html")
+            with open(path, "r", encoding="utf-8") as fh:
+                return fh.read()
+
+        @app.get("/gl/ui/static/{fname}")
+        def assets(fname: str):
+            path = os.path.join(static_dir, fname)
+            if not os.path.exists(path):
+                from forgecore.admin_api import HTTPException
+
+                raise HTTPException(404)
+            with open(path, "rb") as fh:
+                data = fh.read()
+            mime = "text/plain"
+            if fname.endswith(".js"):
+                mime = "application/javascript"
+            elif fname.endswith(".css"):
+                mime = "text/css"
+            elif fname.endswith(".html"):
+                mime = "text/html"
+            return Response(content=data, media_type=mime)

--- a/modules/status_dashboard/module.json
+++ b/modules/status_dashboard/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "status_dashboard",
+  "version": "1.0.0",
+  "provides": ["ui.dashboard@1.0"],
+  "requires": ["orders.service@^1.0", "shipping.rules@^1.0", "printing.service@^1.0", "events.log@^1.0"],
+  "entry": "entry:DashboardModule"
+}

--- a/modules/status_dashboard/static/app.js
+++ b/modules/status_dashboard/static/app.js
@@ -1,0 +1,97 @@
+const statuses = ["New","Printed","Addressed","Bags Pulled","Ship Method Chosen","Shipped","Completed"];
+let orders = [];
+let selected = new Set();
+
+async function fetchOrders(){
+  const res = await fetch('/gl/orders');
+  orders = await res.json();
+  render();
+}
+
+function render(){
+  const board = document.getElementById('board');
+  board.innerHTML='';
+  statuses.forEach(st=>{
+    const col = document.createElement('div');
+    col.className='col';
+    col.dataset.status=st;
+    const h=document.createElement('h2');h.textContent=st;col.appendChild(h);
+    board.appendChild(col);
+  });
+  orders.forEach(o=>{
+    const col = board.querySelector(`.col[data-status="${o.status}"]`);
+    if(!col)return;
+    const tile=document.createElement('div');
+    tile.className='tile';
+    tile.innerHTML=`<input type="checkbox" class="sel" data-id="${o.id}">`+
+      `<div class="info">#${o.id} ${o.buyer.name} (${o.destination.zip})<br>`+
+      `wt:${o.computed_weight||''} tier:${o.shipping_tier}`+
+      (o.tracking_number?`<br>trk:${o.tracking_number}`:'')+
+      `</div>`;
+    const actions=document.createElement('div');actions.className='actions';
+    function btn(text, fn){const b=document.createElement('button');b.textContent=text;b.onclick=fn;actions.appendChild(b);}
+    if(o.status==="New") btn('Print Invoice',()=>doAction(`/gl/orders/${o.id}/print/invoice`));
+    if(o.status==="Printed") btn('Addressed',()=>doAction(`/gl/orders/${o.id}/addressed`));
+    if(o.status==="Addressed") btn('Bags Pulled',()=>doAction(`/gl/orders/${o.id}/status/Bags%20Pulled`));
+    if(o.status==="Bags Pulled") btn('Approve Ship',()=>approveShipping(o.id));
+    if(o.status==="Ship Method Chosen") btn('Buy Label',()=>doAction(`/gl/orders/${o.id}/print/label`));
+    if(o.status==="Shipped") btn('Complete',()=>doAction(`/gl/orders/${o.id}/status/Completed`));
+    tile.appendChild(actions);
+    col.appendChild(tile);
+  });
+  document.querySelectorAll('.sel').forEach(cb=>cb.onchange=()=>{
+    if(cb.checked) selected.add(cb.dataset.id); else selected.delete(cb.dataset.id);
+  });
+}
+
+async function doAction(url, method='POST'){
+  await fetch(url,{method});
+  fetchOrders();
+}
+
+async function approveShipping(id){
+  const res = await fetch(`/gl/orders/${id}/shipping/approve`,{method:'POST'});
+  if(res.ok) fetchOrders();
+}
+
+// batch operations
+async function batchPrint(){
+  if(selected.size===0)return;
+  await fetch('/gl/orders/batch/print/invoices',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ids:[...selected]})});
+  fetchOrders();
+}
+async function batchLabel(){
+  if(selected.size===0)return;
+  await fetch('/gl/orders/batch/print/labels',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ids:[...selected]})});
+  fetchOrders();
+}
+async function batchStatus(){
+  const st=document.getElementById('batch-status').value;
+  if(!st||selected.size===0)return;
+  await fetch('/gl/orders/batch/status',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ids:[...selected],status:st})});
+  fetchOrders();
+}
+
+// log drawer poll
+async function pollLogs(){
+  const res=await fetch('/gl/logs');
+  const logs=await res.json();
+  const cont=document.getElementById('logs');
+  cont.innerHTML='';
+  logs.forEach(l=>{
+    const div=document.createElement('div');
+    div.textContent=`${l.ts} ${l.topic} ${l.detail||''}`;
+    cont.appendChild(div);
+  });
+}
+setInterval(pollLogs,3000);
+
+// bindings
+window.onload=()=>{
+  document.getElementById('refresh').onclick=fetchOrders;
+  document.getElementById('batch-print').onclick=batchPrint;
+  document.getElementById('batch-label').onclick=batchLabel;
+  document.getElementById('batch-status').onchange=batchStatus;
+  fetchOrders();
+  pollLogs();
+}

--- a/modules/status_dashboard/static/index.html
+++ b/modules/status_dashboard/static/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>GraniteLedger</title>
+  <link rel="stylesheet" href="/gl/ui/static/styles.css" />
+</head>
+<body>
+  <header>
+    <h1>GraniteLedger</h1>
+    <div id="toolbar">
+      <button id="refresh">Refresh</button>
+      <button id="batch-print">Batch Print Invoices</button>
+      <button id="batch-label">Batch Buy Labels</button>
+      <select id="batch-status">
+        <option value="">Batch Status...</option>
+        <option>Printed</option>
+        <option>Addressed</option>
+        <option>Bags Pulled</option>
+        <option>Ship Method Chosen</option>
+        <option>Shipped</option>
+        <option>Completed</option>
+      </select>
+    </div>
+  </header>
+  <main id="board"></main>
+  <aside id="logdrawer" class="hidden">
+    <h3>Event Log</h3>
+    <input id="logfilter" placeholder="filter" />
+    <div id="logs"></div>
+  </aside>
+  <script src="/gl/ui/static/app.js"></script>
+</body>
+</html>

--- a/modules/status_dashboard/static/styles.css
+++ b/modules/status_dashboard/static/styles.css
@@ -1,0 +1,10 @@
+body{font-family:sans-serif;margin:0;background:#fffaf6;color:#333;}
+header{background:#f9d5c4;padding:10px;display:flex;align-items:center;justify-content:space-between;}
+#toolbar button,#toolbar select{margin-right:5px;}
+#board{display:flex;overflow-x:auto;padding:10px;}
+.col{flex:1;min-width:200px;margin-right:10px;background:#ffece3;border-radius:4px;padding:5px;}
+.col h2{text-align:center;font-size:1.1em;margin:4px 0;}
+.tile{background:#fff;margin:5px 0;padding:5px;border-radius:4px;box-shadow:0 1px 2px rgba(0,0,0,0.1);}
+.tile .actions button{margin:2px;}
+#logdrawer{position:fixed;right:0;top:0;width:300px;height:100%;background:#fff;border-left:1px solid #ccc;padding:10px;overflow:auto;}
+.hidden{display:none;}

--- a/modules/test_kits/entry.py
+++ b/modules/test_kits/entry.py
@@ -1,0 +1,65 @@
+import uuid
+from typing import Any
+from datetime import datetime
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI
+
+
+class TestKitsModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.orders = ctx.registry.get("orders.service@1.0")
+        self.printing = ctx.registry.get("printing.service@1.0")
+        self.OrderModel = ctx.registry.get("orders.models@1.0")
+        ctx.registry.bind("tests.kit@1.0", self)
+
+    def setup_routes(self, app: Any):
+        @app.post("/gl/test/order")
+        def test_order():
+            oid = str(uuid.uuid4())
+            order = self.OrderModel(
+                id=oid,
+                external_id=oid,
+                created_at=datetime.utcnow(),
+                buyer={"name": "Test Buyer"},
+                destination={"zip": "99999", "city": "X", "state": "YY", "country": "US"},
+                items=[{"sku": "SKU1", "name": "Item", "qty": 1, "weight": 1.0}],
+                shipping_tier="Free",
+                totals={"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+            )
+            self.orders.create_or_update(order, test=True)
+            return {"id": oid}
+
+        @app.post("/gl/test/print")
+        def test_print():
+            orders = [o for o in self.orders.list_orders() if o.buyer.get("name") == "Test Buyer"]
+            if not orders:
+                raise HTTPException(404)
+            oid = orders[-1].id
+            self.printing.op_print_invoice(oid, test=True)
+            return {"id": oid}
+
+        @app.post("/gl/test/ship")
+        def test_ship():
+            orders = [o for o in self.orders.list_orders() if o.buyer.get("name") == "Test Buyer"]
+            if not orders:
+                raise HTTPException(404)
+            oid = orders[-1].id
+            order = self.orders.get(oid)
+            method = order.proposed_shipping_method or {
+                "carrier": "USPS",
+                "service": "Ground",
+                "cost": 5.0,
+                "eta_days": 5,
+            }
+            self.orders.update(oid, {"approved_shipping_method": method})
+            self.ctx.event_bus.publish(
+                "order.shipping.approved", {"order_id": oid, "method": method, "test": True}
+            )
+            self.orders.change_status(oid, "Ship Method Chosen")
+            self.printing.op_print_label(oid, test=True)
+            return {"id": oid}

--- a/modules/test_kits/module.json
+++ b/modules/test_kits/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "test_kits",
+  "version": "1.0.0",
+  "provides": ["tests.kit@1.0"],
+  "requires": ["orders.service@^1.0", "printing.service@^1.0"],
+  "entry": "entry:TestKitsModule"
+}

--- a/modules/volusion_webhook/entry.py
+++ b/modules/volusion_webhook/entry.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict
+from forgecore.admin_api import HTTPException
+
+try:
+    from fastapi import FastAPI, Header
+except Exception:  # pragma: no cover
+    from mini_fastapi import FastAPI  # type: ignore
+    Header = lambda default=0: default  # type: ignore
+
+import os, sys
+sys.path.append(os.path.dirname(__file__))
+from normalizer import normalize
+
+
+class VolusionWebhookModule:
+    def on_load(self, ctx):
+        self.ctx = ctx
+        self.service = None
+        self.OrderModel = None
+        ctx.event_bus.subscribe("order.completed", self.on_completed)
+        ctx.registry.bind("webhooks.volusion@1.0", self)
+
+    def on_enable(self):
+        self.service = self.ctx.registry.get("orders.service@1.0")
+        self.OrderModel = self.ctx.registry.get("orders.models@1.0")
+
+    def on_completed(self, payload: Dict[str, Any]):
+        # stub callback
+        self.ctx.event_bus.publish(
+            "volusion.sync", {"order_id": payload.get("order_id")}
+        )
+
+    def ingest_payload(self, item: Dict[str, Any]):
+        data = normalize(item)
+        order = self.OrderModel.parse_obj(data)
+        self.service.create_or_update(order, test=item.get("test") == True)
+        return {"status": "ok", "id": order.id}
+
+    def setup_routes(self, app: Any):
+        @app.post("/gl/webhooks/volusion")
+        def ingest(item: Dict[str, Any], gl_test: int = Header(0)):
+            if gl_test == 1:
+                item["test"] = True
+            return self.ingest_payload(item)

--- a/modules/volusion_webhook/module.json
+++ b/modules/volusion_webhook/module.json
@@ -1,0 +1,7 @@
+{
+  "name": "volusion_webhook",
+  "version": "1.0.0",
+  "provides": ["webhooks.volusion@1.0"],
+  "requires": ["orders.service@^1.0"],
+  "entry": "entry:VolusionWebhookModule"
+}

--- a/modules/volusion_webhook/normalizer.py
+++ b/modules/volusion_webhook/normalizer.py
@@ -1,0 +1,3 @@
+def normalize(payload):
+    # For this demo, payload already resembles Order; ensure required fields.
+    return payload

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pydantic
+fastapi
+uvicorn
+pytest

--- a/run.py
+++ b/run.py
@@ -1,0 +1,25 @@
+from forgecore.runtime import create_runtime
+from forgecore.admin_api import create_app
+
+
+def build_app():
+    rt = create_runtime("modules")
+    rt.start()
+    app = create_app(rt)
+    for state in rt.loader.modules.values():
+        if hasattr(state.instance, "setup_routes"):
+            state.instance.setup_routes(app)
+    return app, rt
+
+
+if __name__ == "__main__":
+    app, _ = build_app()
+    # when running via 'python run.py', start uvicorn if available
+    try:
+        import uvicorn
+
+        uvicorn.run(app, host="0.0.0.0", port=8765)
+    except Exception:
+        from forgecore.admin_api import Response
+
+        print("App built. Use a WSGI server to run.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+import os
+import pytest
+import sys
+import shutil
+BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(BASE)
+sys.path.append(os.path.join(BASE, "ForgeCore"))
+
+from forgecore.runtime import create_runtime
+try:
+    from fastapi import FastAPI
+except ModuleNotFoundError:  # pragma: no cover
+    from mini_fastapi import FastAPI  # type: ignore
+
+
+@pytest.fixture
+def runtime():
+    shutil.rmtree("modules/_storage", ignore_errors=True)
+    rt = create_runtime("modules")
+    rt.start()
+    yield rt
+    shutil.rmtree("modules/_storage", ignore_errors=True)
+
+
+@pytest.fixture
+def orders(runtime):
+    return runtime.registry.get("orders.service@1.0")
+
+
+@pytest.fixture
+def printing(runtime):
+    return runtime.registry.get("printing.service@1.0")
+
+
+@pytest.fixture
+def events(runtime):
+    return runtime.registry.get("events.log@1.0")
+
+
+@pytest.fixture
+def order_model(runtime):
+    return runtime.registry.get("orders.models@1.0")
+
+
+@pytest.fixture
+def volusion(runtime):
+    return runtime.registry.get("webhooks.volusion@1.0")
+
+
+@pytest.fixture
+def orders_api(runtime):
+    class Dummy:
+        def __init__(self):
+            self.routes = []
+
+        def get(self, path, **kwargs):
+            def deco(fn):
+                self.routes.append(type("R", (), {"path": path, "endpoint": fn}))
+                return fn
+            return deco
+
+        def post(self, path, **kwargs):
+            return self.get(path, **kwargs)
+
+        def patch(self, path, **kwargs):
+            return self.get(path, **kwargs)
+
+    app = Dummy()
+    mod = runtime.loader.modules["orders_core"].instance
+    mod.setup_routes(app)
+    return app

--- a/tests/test_batch_ops.py
+++ b/tests/test_batch_ops.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+
+def make_order(id):
+    return {
+        "id": id,
+        "external_id": id,
+        "created_at": datetime.utcnow(),
+        "buyer": {"name": "Batch"},
+        "destination": {"zip": "99990", "city": "X", "state": "Y", "country": "US"},
+        "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": 1.0}],
+        "shipping_tier": "Free",
+        "totals": {"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+    }
+
+
+def test_batch_ops(orders_api, orders, order_model, runtime):
+    o1 = order_model(**make_order("b1"))
+    o2 = order_model(**make_order("b2"))
+    orders.create_or_update(o1)
+    orders.create_or_update(o2)
+    # helpers
+    def call(path, payload):
+        func = next(r for r in orders_api.routes if r.path == path).endpoint
+        return func(payload)
+
+    data = call("/gl/orders/batch/print/invoices", {"ids": ["b1", "b2"]})
+    assert "b1" in data and "b2" in data
+    # prepare for label on b1
+    printing_method = orders.get("b1").proposed_shipping_method
+    orders.update("b1", {"approved_shipping_method": printing_method})
+    runtime.event_bus.publish("order.shipping.approved", {"order_id": "b1", "method": printing_method})
+    orders.change_status("b1", "Addressed")
+    orders.change_status("b1", "Bags Pulled")
+    orders.change_status("b1", "Ship Method Chosen")
+    # batch print labels (b1 ok, b2 fails)
+    data = call("/gl/orders/batch/print/labels", {"ids": ["b1", "b2"]})
+    assert "tracking" in data["b1"]
+    assert "error" in data["b2"]
+    # batch status advance both to Completed (b2 should error due to flow)
+    result = call(
+        "/gl/orders/batch/status", {"ids": ["b1", "b2"], "status": "Completed"}
+    )
+    assert result["b1"]["ok"] is True
+    assert "error" in result["b2"]

--- a/tests/test_order_flow.py
+++ b/tests/test_order_flow.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+
+def make_order(id):
+    return {
+        "id": id,
+        "external_id": id,
+        "created_at": datetime.utcnow(),
+        "buyer": {"name": "Flow"},
+        "destination": {"zip": "99999", "city": "X", "state": "Y", "country": "US"},
+        "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": 1.0}],
+        "shipping_tier": "Free",
+        "totals": {"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+    }
+
+
+def test_full_flow(orders, order_model, printing, events, runtime):
+    order = order_model(**make_order("x1"))
+    orders.create_or_update(order)
+    # print invoice
+    printing.op_print_invoice("x1")
+    orders.change_status("x1", "Addressed")
+    orders.change_status("x1", "Bags Pulled")
+    # approve shipping
+    method = orders.get("x1").proposed_shipping_method
+    orders.update("x1", {"approved_shipping_method": method})
+    runtime.event_bus.publish("order.shipping.approved", {"order_id": "x1", "method": method})
+    orders.change_status("x1", "Ship Method Chosen")
+    # print label
+    printing.op_print_label("x1")
+    orders.change_status("x1", "Completed")
+    data = orders.get("x1").dict()
+    assert data["status"] == "Completed"
+    assert data["tracking_number"] is not None
+    topics = [e["topic"] for e in events.list_events()]
+    for t in [
+        "order.received",
+        "order.shipping.selected",
+        "order.shipping.approved",
+        "order.invoice.printed",
+        "order.label.printed",
+        "order.completed",
+    ]:
+        assert t in topics

--- a/tests/test_printing_flows.py
+++ b/tests/test_printing_flows.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+
+def make_order(id):
+    return {
+        "id": id,
+        "external_id": id,
+        "created_at": datetime.utcnow(),
+        "buyer": {"name": "Print"},
+        "destination": {"zip": "99990", "city": "X", "state": "Y", "country": "US"},
+        "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": 1.0}],
+        "shipping_tier": "Free",
+        "totals": {"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+    }
+
+
+def test_reprint_and_void(orders, order_model, printing, events, runtime):
+    order = order_model(**make_order("p1"))
+    orders.create_or_update(order)
+    printing.op_print_invoice("p1")
+    orders.change_status("p1", "Addressed")
+    orders.change_status("p1", "Bags Pulled")
+    method = orders.get("p1").proposed_shipping_method
+    orders.update("p1", {"approved_shipping_method": method})
+    runtime.event_bus.publish("order.shipping.approved", {"order_id": "p1", "method": method})
+    orders.change_status("p1", "Ship Method Chosen")
+    printing.op_print_label("p1")
+    tracking1 = orders.get("p1").tracking_number
+    # reprints
+    printing.op_reprint_invoice("p1")
+    printing.op_reprint_label("p1")
+    # void and rebuy
+    printing.op_void_rebuy("p1")
+    tracking2 = orders.get("p1").tracking_number
+    assert tracking1 != tracking2
+    assert orders.get("p1").status == "Shipped"
+    topics = [e["topic"] for e in events.list_events()]
+    assert "order.label.voided" in topics
+    assert topics.count("order.invoice.printed") >= 2
+    assert topics.count("order.label.printed") >= 2

--- a/tests/test_shipping_rules.py
+++ b/tests/test_shipping_rules.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+
+def make_order(id, tier, zip_code, weight=1.0):
+    return {
+        "id": id,
+        "external_id": id,
+        "created_at": datetime.utcnow(),
+        "buyer": {"name": "Test"},
+        "destination": {"zip": zip_code, "city": "X", "state": "Y", "country": "US"},
+        "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": weight}],
+        "shipping_tier": tier,
+        "totals": {"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+    }
+
+
+def test_weight_and_free_rule(orders, order_model):
+    order = order_model(**make_order("1", "Free", "99990"))
+    orders.create_or_update(order)
+    data = orders.get("1").dict()
+    assert data["computed_weight"] == 1.5
+    # diff <0.30 and faster -> UPS
+    assert data["proposed_shipping_method"]["carrier"] == "UPS"
+
+
+def test_free_cheapest_when_expensive(orders, order_model):
+    order = order_model(**make_order("2", "Free", "99999"))
+    orders.create_or_update(order)
+    data = orders.get("2").dict()
+    assert data["proposed_shipping_method"]["carrier"] == "USPS"
+
+
+def test_zip_override(orders, order_model):
+    order = order_model(**make_order("3", "Free", "03224"))
+    orders.create_or_update(order)
+    data = orders.get("3").dict()
+    assert data["proposed_shipping_method"]["carrier"] == "Home"
+
+
+def test_priority_default(orders, order_model):
+    order = order_model(**make_order("4", "Priority", "99990"))
+    orders.create_or_update(order)
+    data = orders.get("4").dict()
+    assert data["proposed_shipping_method"]["service"] == "Priority"
+
+
+def test_priority_zip_override(orders, order_model):
+    order = order_model(**make_order("5", "Priority", "03224"))
+    orders.create_or_update(order)
+    data = orders.get("5").dict()
+    assert data["proposed_shipping_method"]["carrier"] == "Home"

--- a/tests/test_webhook_idempotency.py
+++ b/tests/test_webhook_idempotency.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+payload = {
+    "id": "ext1",
+    "created_at": datetime.utcnow(),
+    "buyer": {"name": "Webhook"},
+    "destination": {"zip": "99999", "city": "X", "state": "Y", "country": "US"},
+    "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": 1.0}],
+    "shipping_tier": "Free",
+    "totals": {"subtotal": 10.0, "shipping": 0.0, "tax": 0.0, "grand_total": 10.0},
+}
+
+
+def test_idempotent_webhook(volusion, orders):
+    volusion.ingest_payload(payload)
+    volusion.ingest_payload(payload)
+    assert len(orders.list_orders()) == 1


### PR DESCRIPTION
## Summary
- finalize orders core with addressed endpoint and batch operations
- implement deterministic shipping rules, printable artifacts, and logging with filters
- deliver dashboard UI, volusion test header handling, and expanded tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa212041a4832e8cdaa4cadb68a0c3