### PR TITLE
Add admin UI test utilities and shipping modal

### DIFF
--- a/ForgeCore/forgecore/admin_ui/static/app.js
+++ b/ForgeCore/forgecore/admin_ui/static/app.js
@@ -1,4 +1,142 @@
-fetch('/api/modules').then(r=>r.json()).then(d=>{
-  const el = document.getElementById('content');
-  el.innerText = JSON.stringify(d, null, 2);
+// basic state
+let orders = [];
+let focusedId = null;
+
+function loadOrders() {
+  fetch('/gl/orders').then(r => r.json()).then(data => {
+    orders = data;
+    const cont = document.getElementById('orders');
+    cont.innerHTML = '';
+    data.forEach(o => {
+      const div = document.createElement('div');
+      div.className = 'order';
+      div.dataset.id = o.id;
+      div.textContent = `${o.id} - ${o.status}`;
+      div.addEventListener('click', () => focusOrder(o.id));
+      cont.appendChild(div);
+    });
+    if (focusedId) focusOrder(focusedId);
+  });
+}
+
+function focusOrder(id) {
+  focusedId = id;
+  document.querySelectorAll('.order').forEach(el => el.classList.remove('focused'));
+  const el = document.querySelector(`.order[data-id="${id}"]`);
+  if (el) {
+    el.classList.add('focused');
+    el.scrollIntoView({ block: 'center' });
+  }
+}
+
+function toolbarInit() {
+  const tb = document.getElementById('toolbar');
+  const btnOrder = document.createElement('button');
+  btnOrder.textContent = 'Test: New Order';
+  btnOrder.onclick = () => fetch('/gl/test/order', { method: 'POST' }).then(loadAll);
+  tb.appendChild(btnOrder);
+  const btnPrint = document.createElement('button');
+  btnPrint.textContent = 'Test: Print';
+  btnPrint.onclick = () => fetch('/gl/test/print', { method: 'POST' }).then(loadAll);
+  tb.appendChild(btnPrint);
+  const btnShip = document.createElement('button');
+  btnShip.textContent = 'Test: Ship';
+  btnShip.onclick = () => fetch('/gl/test/ship', { method: 'POST' }).then(loadAll);
+  tb.appendChild(btnShip);
+}
+
+function loadLogs(filter = '') {
+  let url = '/gl/logs';
+  if (filter) url += `?topic=${encodeURIComponent(filter)}`;
+  fetch(url).then(r => r.json()).then(data => {
+    const cont = document.getElementById('log-entries');
+    cont.innerHTML = '';
+    data.forEach(ev => {
+      const row = document.createElement('div');
+      row.textContent = `${ev.ts} ${ev.topic} ${ev.order_id || ''}`;
+      row.dataset.oid = ev.order_id;
+      row.addEventListener('click', () => {
+        if (ev.order_id) focusOrder(ev.order_id);
+      });
+      cont.appendChild(row);
+    });
+  });
+}
+
+document.getElementById('log-filter').addEventListener('input', e => {
+  loadLogs(e.target.value);
 });
+
+function showShippingModal(oid) {
+  const modal = document.getElementById('modal');
+  fetch(`/gl/orders/${oid}/shipping/options`).then(r => r.json()).then(opts => {
+    modal.innerHTML = '';
+    const box = document.createElement('div');
+    box.className = 'box';
+    box.innerHTML = '<h3>Select Shipping</h3>';
+    opts.forEach(opt => {
+      const btn = document.createElement('button');
+      btn.textContent = `${opt.carrier} ${opt.service} $${opt.cost} - ${opt.rationale}`;
+      btn.addEventListener('click', () => {
+        fetch(`/gl/orders/${oid}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ proposed_shipping_method: opt })
+        }).then(() => fetch(`/gl/orders/${oid}/shipping/approve`, { method: 'POST' }))
+        .then(() => { modal.classList.add('hidden'); loadOrders(); });
+      });
+      box.appendChild(btn);
+    });
+    const cancel = document.createElement('button');
+    cancel.textContent = 'Cancel';
+    cancel.onclick = () => modal.classList.add('hidden');
+    box.appendChild(cancel);
+    modal.appendChild(box);
+    modal.classList.remove('hidden');
+  });
+}
+
+function printInvoice(id) {
+  fetch(`/gl/orders/${id}/print/invoice`, { method: 'POST' }).then(() => { loadOrders(); loadLogs(); });
+}
+function markAddressed(id) {
+  fetch(`/gl/orders/${id}/status/Addressed`, { method: 'POST' }).then(loadOrders);
+}
+function markBags(id) {
+  fetch(`/gl/orders/${id}/status/Bags%20Pulled`, { method: 'POST' }).then(loadOrders);
+}
+function printLabel(id) {
+  fetch(`/gl/orders/${id}`).then(r => r.json()).then(o => {
+    if (!o.approved_shipping_method) return;
+    fetch(`/gl/orders/${id}/print/label`, { method: 'POST' }).then(() => { loadOrders(); loadLogs(); });
+  });
+}
+function markComplete(id) {
+  fetch(`/gl/orders/${id}/status/Completed`, { method: 'POST' }).then(loadOrders);
+}
+
+function batchPrintLabels(ids) {
+  Promise.all(ids.map(i => fetch(`/gl/orders/${i}`).then(r => r.json()))).then(data => {
+    const ok = data.filter(o => o.approved_shipping_method).map(o => o.id);
+    ok.forEach(i => fetch(`/gl/orders/${i}/print/label`, { method: 'POST' }));
+  });
+}
+
+document.addEventListener('keydown', e => {
+  if (!focusedId) return;
+  const k = e.key.toUpperCase();
+  if (k === 'P') printInvoice(focusedId);
+  if (k === 'A') markAddressed(focusedId);
+  if (k === 'B') markBags(focusedId);
+  if (k === 'M') showShippingModal(focusedId);
+  if (k === 'L') printLabel(focusedId);
+  if (k === 'C') markComplete(focusedId);
+});
+
+function loadAll() {
+  loadOrders();
+  loadLogs(document.getElementById('log-filter').value);
+}
+
+toolbarInit();
+loadAll();

--- a/ForgeCore/forgecore/admin_ui/static/index.html
+++ b/ForgeCore/forgecore/admin_ui/static/index.html
@@ -7,7 +7,13 @@
 </head>
 <body>
   <h1>ForgeCore Admin</h1>
-  <div id="content"></div>
+  <div id="toolbar"></div>
+  <div id="orders"></div>
+  <div id="logs">
+    <input id="log-filter" placeholder="filter logs" />
+    <div id="log-entries"></div>
+  </div>
+  <div id="modal" class="hidden"></div>
   <script src="app.js"></script>
 </body>
 </html>

--- a/ForgeCore/forgecore/admin_ui/static/style.css
+++ b/ForgeCore/forgecore/admin_ui/static/style.css
@@ -1,1 +1,13 @@
 body { font-family: sans-serif; margin: 2em; }
+
+#toolbar button { margin-right: 0.5em; }
+
+.order { border: 1px solid #ccc; padding: 0.5em; margin: 0.5em 0; }
+.order.focused { outline: 2px solid blue; }
+
+#logs { margin-top: 2em; border-top: 1px solid #ccc; padding-top: 1em; }
+#log-entries div { cursor: pointer; }
+
+#modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.3); display: flex; align-items: center; justify-content: center; }
+#modal.hidden { display: none; }
+#modal .box { background: #fff; padding: 1em; }

--- a/modules/events_log/entry.py
+++ b/modules/events_log/entry.py
@@ -46,5 +46,10 @@ class EventsLogModule:
 
     def setup_routes(self, app: Any):
         @app.get("/gl/logs")
-        def get_logs():
-            return self.list_events()
+        def get_logs(topic: str | None = None, order_id: str | None = None):
+            events = self.list_events()
+            if topic:
+                events = [e for e in events if e.get("topic") == topic]
+            if order_id:
+                events = [e for e in events if e.get("order_id") == order_id]
+            return events

--- a/modules/shipping_rules/entry.py
+++ b/modules/shipping_rules/entry.py
@@ -100,7 +100,14 @@ class ShippingRulesModule:
             order = self.service.get(oid)
             if not order:
                 raise HTTPException(404)
-            opts = self.shipping_options(order.dict())[:2]
+            data = order.dict()
+            opts = self.shipping_options(data)[:2]
+            chosen = self.choose_method(data)
+            for o in opts:
+                if o["carrier"] == chosen.get("carrier") and o["service"] == chosen.get("service"):
+                    o["rationale"] = chosen.get("rationale")
+                else:
+                    o["rationale"] = ""
             return opts
 
         @app.post("/gl/orders/{oid}/shipping/approve")


### PR DESCRIPTION
## Summary
- add toolbar buttons to create test orders, print invoice and ship
- show shipping options modal and approve chosen method
- filter and navigate via log drawer with keyboard shortcuts and order focus
- allow log queries on backend and expose rationale for shipping options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa51d8f8a8832eaea34b4426c09189