### PR TITLE
refactor: update Pydantic API usage

### DIFF
--- a/modules/orders_core/entry.py
+++ b/modules/orders_core/entry.py
@@ -27,27 +27,27 @@ class OrdersCoreModule:
     def setup_routes(self, app: Any):
         @app.get("/gl/orders")
         def list_orders():
-            return [o.dict() for o in self.service.list_orders()]
+            return [o.model_dump() for o in self.service.list_orders()]
 
         @app.get("/gl/orders/{oid}")
         def get_order(oid: str):
             order = self.service.get(oid)
             if not order:
                 raise HTTPException(404)
-            return order.dict()
+            return order.model_dump()
 
         @app.post("/gl/orders")
         def create_order(item: Dict[str, Any]):
-            order = Order.parse_obj(item)
+            order = Order.model_validate(item)
             self.service.create_or_update(order)
-            return order.dict()
+            return order.model_dump()
 
         @app.patch("/gl/orders/{oid}")
         def update_order(oid: str, item: Dict[str, Any]):
             order = self.service.update(oid, item)
             if not order:
                 raise HTTPException(404)
-            return order.dict()
+            return order.model_dump()
 
         @app.post("/gl/orders/{oid}/status/{status}")
         def change_status(oid: str, status: str):
@@ -57,6 +57,6 @@ class OrdersCoreModule:
                 raise HTTPException(400)
             if not order:
                 raise HTTPException(404)
-            return order.dict()
+            return order.model_dump()
 
         self.app = app

--- a/modules/orders_core/models.py
+++ b/modules/orders_core/models.py
@@ -58,6 +58,3 @@ class Order(BaseModel):
     tracking_number: Optional[str] = None
     totals: MoneyTotals
     history: List[HistoryEntry] = Field(default_factory=list)
-
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}

--- a/modules/orders_core/service.py
+++ b/modules/orders_core/service.py
@@ -51,7 +51,7 @@ class OrderService:
         data = self.storage.load(self.module_name, f"order_{oid}")
         if not data:
             return None
-        return Order.parse_obj(data)
+        return Order.model_validate(data)
 
     # public API
     def list_orders(self) -> List[Order]:

--- a/modules/shipping_rules/entry.py
+++ b/modules/shipping_rules/entry.py
@@ -100,7 +100,7 @@ class ShippingRulesModule:
             order = self.service.get(oid)
             if not order:
                 raise HTTPException(404)
-            data = order.dict()
+            data = order.model_dump()
             opts = self.shipping_options(data)[:2]
             chosen = self.choose_method(data)
             for o in opts:

--- a/modules/volusion_webhook/entry.py
+++ b/modules/volusion_webhook/entry.py
@@ -31,7 +31,7 @@ class VolusionWebhookModule:
 
     def ingest_payload(self, item: Dict[str, Any]):
         data = normalize(item)
-        order = self.OrderModel.parse_obj(data)
+        order = self.OrderModel.model_validate(data)
         self.service.create_or_update(order, test=item.get("test") == True)
         return {"status": "ok", "id": order.id}
 

--- a/tests/test_order_flow.py
+++ b/tests/test_order_flow.py
@@ -29,7 +29,7 @@ def test_full_flow(orders, order_model, printing, events, runtime):
     # print label
     printing.op_print_label("x1")
     orders.change_status("x1", "Completed")
-    data = orders.get("x1").dict()
+    data = orders.get("x1").model_dump()
     assert data["status"] == "Completed"
     assert data["tracking_number"] is not None
     topics = [e["topic"] for e in events.list_events()]

--- a/tests/test_shipping_rules.py
+++ b/tests/test_shipping_rules.py
@@ -17,7 +17,7 @@ def make_order(id, tier, zip_code, weight=1.0):
 def test_weight_and_free_rule(orders, order_model):
     order = order_model(**make_order("1", "Free", "99999"))
     orders.create_or_update(order)
-    data = orders.get("1").dict()
+    data = orders.get("1").model_dump()
     assert data["computed_weight"] == 1.5
     assert data["proposed_shipping_method"]["carrier"] == "UPS"
 
@@ -25,12 +25,12 @@ def test_weight_and_free_rule(orders, order_model):
 def test_zip_override(orders, order_model):
     order = order_model(**make_order("2", "Free", "03224"))
     orders.create_or_update(order)
-    data = orders.get("2").dict()
+    data = orders.get("2").model_dump()
     assert data["proposed_shipping_method"]["carrier"] == "Home"
 
 
 def test_priority_zip_override(orders, order_model):
     order = order_model(**make_order("3", "Priority", "03224"))
     orders.create_or_update(order)
-    data = orders.get("3").dict()
+    data = orders.get("3").model_dump()
     assert data["proposed_shipping_method"]["carrier"] == "Home"


### PR DESCRIPTION
## Summary
- replace deprecated `parse_obj` and `dict()` with `model_validate` and `model_dump`
- adjust webhook and order modules to new Pydantic v2 APIs
- update tests for new serialization helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa532eed94832ea92ca290221f8d17