### PR TITLE
Use timezone-aware datetimes and modern module loading

### DIFF
--- a/ForgeCore/forgecore/loader.py
+++ b/ForgeCore/forgecore/loader.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import json
 import logging
 import os
@@ -56,10 +57,12 @@ class ModuleLoader:
 
     def _load_entry(self, module_path: str, spec: str) -> Any:
         mod_name, _, cls_name = spec.partition(":")
-        module = importlib.machinery.SourceFileLoader(
-            mod_name,
-            os.path.join(module_path, mod_name + ".py"),
-        ).load_module()
+        spec = importlib.util.spec_from_file_location(
+            mod_name, os.path.join(module_path, mod_name + ".py")
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)  # type: ignore[attr-defined]
         cls = getattr(module, cls_name)
         return cls()
 

--- a/modules/events_log/entry.py
+++ b/modules/events_log/entry.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any
 from forgecore.admin_api import HTTPException
 
@@ -32,7 +32,7 @@ class EventsLogModule:
 
     def _handle(self, topic: str, payload: Any):
         rec = {
-            "ts": datetime.utcnow().isoformat(),
+            "ts": datetime.now(UTC).isoformat(),
             "topic": topic,
             "order_id": payload.get("order_id"),
             "detail": payload.get("detail"),

--- a/modules/orders_core/service.py
+++ b/modules/orders_core/service.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Dict, List, Optional
 import os, sys
 sys.path.append(os.path.dirname(__file__))
@@ -71,7 +71,7 @@ class OrderService:
         else:
             self.external[order.external_id] = order.id if order.external_id else order.id
         order.history.append({
-            "ts": datetime.utcnow(),
+            "ts": datetime.now(UTC),
             "event": "order.received",
             "detail": "test" if test else "received",
         })
@@ -87,7 +87,7 @@ class OrderService:
         for k, v in data.items():
             setattr(order, k, v)
         order.history.append({
-            "ts": datetime.utcnow(),
+            "ts": datetime.now(UTC),
             "event": "order.updated",
             "detail": "updated",
         })
@@ -105,7 +105,7 @@ class OrderService:
             raise ValueError("illegal transition")
         order.status = new_status
         order.history.append({
-            "ts": datetime.utcnow(),
+            "ts": datetime.now(UTC),
             "event": "order.status.changed",
             "detail": new_status,
         })

--- a/modules/printing_service/entry.py
+++ b/modules/printing_service/entry.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any
 from forgecore.admin_api import HTTPException
 
@@ -21,7 +21,7 @@ class PrintingServiceModule:
     # helpers ------------------------------------------------------------
     def _write_file(self, kind: str, oid: str, content: str) -> str:
         base = self.ctx.storage._module_dir(self.ctx.manifest["name"])  # type: ignore
-        ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
         path = os.path.join(base, kind, oid)
         os.makedirs(path, exist_ok=True)
         file_path = os.path.join(path, f"{ts}.txt")
@@ -45,7 +45,7 @@ class PrintingServiceModule:
             raise HTTPException(404)
         if not order.approved_shipping_method:
             raise HTTPException(400)
-        tracking = f"TRK{int(datetime.utcnow().timestamp())}"
+        tracking = f"TRK{int(datetime.now(UTC).timestamp())}"
         path = self._write_file("labels", oid, f"Label {tracking}")
         self.service.update(oid, {"tracking_number": tracking})
         self.ctx.event_bus.publish("order.label.purchased", {"order_id": oid, "detail": tracking, "test": test})
@@ -71,7 +71,7 @@ class PrintingServiceModule:
         if not order or not order.tracking_number:
             raise HTTPException(404)
         self.ctx.event_bus.publish("order.label.voided", {"order_id": oid, "detail": order.tracking_number, "test": test})
-        tracking = f"TRK{int(datetime.utcnow().timestamp())}R"
+        tracking = f"TRK{int(datetime.now(UTC).timestamp())}R"
         path = self._write_file("labels", oid, f"Label {tracking}")
         self.service.update(oid, {"tracking_number": tracking})
         self.ctx.event_bus.publish("order.label.purchased", {"order_id": oid, "detail": tracking, "test": test})

--- a/modules/test_kits/entry.py
+++ b/modules/test_kits/entry.py
@@ -1,6 +1,6 @@
 import uuid
 from typing import Any
-from datetime import datetime
+from datetime import datetime, UTC
 from forgecore.admin_api import HTTPException
 
 try:
@@ -24,7 +24,7 @@ class TestKitsModule:
             order = self.OrderModel(
                 id=oid,
                 external_id=oid,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC),
                 buyer={"name": "Test Buyer"},
                 destination={"zip": "99999", "city": "X", "state": "YY", "country": "US"},
                 items=[{"sku": "SKU1", "name": "Item", "qty": 1, "weight": 1.0}],

--- a/tests/test_order_flow.py
+++ b/tests/test_order_flow.py
@@ -1,11 +1,11 @@
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 def make_order(id):
     return {
         "id": id,
         "external_id": id,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(UTC),
         "buyer": {"name": "Flow"},
         "destination": {"zip": "99999", "city": "X", "state": "Y", "country": "US"},
         "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": 1.0}],

--- a/tests/test_shipping_rules.py
+++ b/tests/test_shipping_rules.py
@@ -1,11 +1,11 @@
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 def make_order(id, tier, zip_code, weight=1.0):
     return {
         "id": id,
         "external_id": id,
-        "created_at": datetime.utcnow(),
+        "created_at": datetime.now(UTC),
         "buyer": {"name": "Test"},
         "destination": {"zip": zip_code, "city": "X", "state": "Y", "country": "US"},
         "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": weight}],

--- a/tests/test_webhook_idempotency.py
+++ b/tests/test_webhook_idempotency.py
@@ -1,8 +1,8 @@
-from datetime import datetime
+from datetime import datetime, UTC
 
 payload = {
     "id": "ext1",
-    "created_at": datetime.utcnow(),
+    "created_at": datetime.now(UTC),
     "buyer": {"name": "Webhook"},
     "destination": {"zip": "99999", "city": "X", "state": "Y", "country": "US"},
     "items": [{"sku": "A", "name": "Item", "qty": 1, "weight": 1.0}],


### PR DESCRIPTION
## Summary
- switch to `datetime.now(UTC)` throughout modules and tests
- load modules via `importlib.util.spec_from_file_location` to avoid deprecated `load_module`
- ensure tests run without deprecation warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5eb11c48832ebf22e93c61a2f395