### PR TITLE
Fix import path and normalize shipping rules

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,3 +1,9 @@
+import os
+import sys
+
+BASE = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(BASE, "ForgeCore"))
+
 from forgecore.runtime import create_runtime
 from forgecore.admin_api import create_app
 


### PR DESCRIPTION
## Summary
- ensure run.py adds ForgeCore to sys.path before importing runtime
- emit ShipMethod models from shipping rules and serialize events
- parse shipping method selections with ShipMethod.model_validate for consistent validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa6de93cb0832ea270de5f31375cee