### PR TITLE
Clean up events log module

### DIFF
--- a/modules/events_log/entry.py
+++ b/modules/events_log/entry.py
@@ -1,7 +1,5 @@
 from datetime import datetime, UTC
 from typing import Any
-import json
-from forgecore.admin_api import HTTPException
 
 try:
     from fastapi import FastAPI
@@ -45,7 +43,7 @@ class EventsLogModule:
     def list_events(self):
         return list(self.events)
 
-    def setup_routes(self, app: Any):
+    def setup_routes(self, app: FastAPI):
         @app.get("/gl/logs")
         def get_logs(
             topic: str | None = None,


### PR DESCRIPTION
## Summary
- remove stray merge conflict markers and unused imports from events log module
- type hint FastAPI app and ensure events log supports order topics and filtering

## Testing
- `ruff check modules/events_log/entry.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab13903654832e83c17b91533bdeb3